### PR TITLE
Fix oembed references

### DIFF
--- a/src/richtext.js
+++ b/src/richtext.js
@@ -48,9 +48,9 @@ function serializeImage(linkResolver, element) {
 
 function serializeEmbed(element) {
   return (`
-    <div data-oembed="${element.embed_url}"
-      data-oembed-type="${element.type}"
-      data-oembed-provider="${element.provider_name}"
+    <div data-oembed="${element.oembed.embed_url}"
+      data-oembed-type="${element.oembed.type}"
+      data-oembed-provider="${element.oembed.provider_name}"
       ${label(element)}>
           
       ${element.oembed.html}


### PR DESCRIPTION
Given that these values are contained in the `oembed` object coming down from the Prismic API, it seems like these references were just typos. The embed still works, but these data values are being set to `undefined` as it is.